### PR TITLE
Add options to set user and group ID in volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN apk --no-cache add \
   tini \
   bash \
   samba \
-  tzdata && \
+  tzdata \
+  shadow && \
   addgroup -S smb && \
   rm -rf /tmp/* /var/cache/apk/*
   
@@ -18,6 +19,8 @@ EXPOSE 139 445
 
 ENV USER "samba"
 ENV PASS "secret"
+ENV UID 1000
+ENV GID 1000
 
 HEALTHCHECK --interval=60s --timeout=15s CMD smbclient -L \\localhost -U % -m SMB3
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     environment:
       USER: "samba"
       PASS: "secret"
+      UID: 1000
+      GID: 1000
     ports:
       - 445:445
     volumes:

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,8 @@ services:
     environment:
       USER: "samba"
       PASS: "secret"
+      UID: 1000    # Optional, default 1000
+      GID: 1000    # Optional, default 1000
     ports:
       - 445:445
     volumes:
@@ -35,7 +37,7 @@ services:
 Via `docker run`
 
 ```bash
-docker run -it --rm -p 445:445 -v "/home/example:/storage" -e "USER=samba" -e "PASS=secret" dockurr/samba
+docker run -it --rm -p 445:445 -v "/home/example:/storage" -e "USER=samba" -e "PASS=secret" -e "UID=1000" -e "GID=1000"dockurr/samba
 ```
 
 ## FAQ

--- a/samba.sh
+++ b/samba.sh
@@ -1,14 +1,52 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+# Set variables for group and share directory
 group="smb"
 share="/storage"
 
-id -u "$USER" &>/dev/null || adduser -S -D -H -h /tmp -s /sbin/nologin -G "$group" -g 'Samba User' "$USER" > /dev/null
-echo -e "$PASS\n$PASS" | smbpasswd -a -s "$USER" > /dev/null
+# Check if the smb group exists, if not, create it
+if ! getent group "$group" &>/dev/null; then
+    groupadd "$group" || { echo "Failed to create group $group"; exit 1; }
+fi
 
-mkdir -p "$share"
-chmod -R 0770 "$share"
-chown "$USER:$group" "$share"
+# Check if the user already exists, if not, create it
+if ! id "$USER" &>/dev/null; then
+    adduser -S -D -H -h /tmp -s /sbin/nologin -G "$group" -g 'Samba User' "$USER" || { echo "Failed to create user $USER"; exit 1; }
+fi
 
+# Get the current user and group IDs
+OldUID=$(id -u "$USER")
+OldGID=$(getent group "$group" | cut -d: -f3)
+
+# Change the UID and GID of the user and group if necessary
+if [[ $OldUID != $UID ]]; then
+    usermod -u "$UID" "$USER" || { echo "Failed to change UID for $USER"; exit 1; }
+fi
+
+if [[ $OldGID != $GID ]]; then
+    groupmod -g "$GID" "$group" || { echo "Failed to change GID for group $group"; exit 1; }
+fi
+
+# Change ownership of files and directories
+find / -path "$share" -prune -o -group "$OldGID" -exec chgrp -h "$group" {} \;
+find / -path "$share" -prune -o -user "$OldUID" -exec chown -h "$USER" {} \;
+
+# Change Samba password
+echo -e "$PASS\n$PASS" | smbpasswd -a -s "$USER" || { echo "Failed to change Samba password for $USER"; exit 1; }
+
+# Update force user and force group in smb.conf
+sed -i "s/^\(\s*\)force user =.*/\1force user = $USER/" "/etc/samba/smb.conf"
+sed -i "s/^\(\s*\)force group =.*/\1force group = $group/" "/etc/samba/smb.conf"
+
+# Create shared directory and set permissions
+mkdir -p "$share" || { echo "Failed to create directory $share"; exit 1; }
+chmod -R 0770 "$share" || { echo "Failed to set permissions for directory $share"; exit 1; }
+chown -R "$USER:$group" "$share" || { echo "Failed to set ownership for directory $share"; exit 1; }
+
+# Start the Samba daemon with the following options:
+#  --foreground: Run in the foreground instead of daemonizing.
+#  --debug-stdout: Send debug output to stdout.
+#  --debuglevel=1: Set debug verbosity level to 1.
+#  --no-process-group: Don't create a new process group for the daemon.
 exec smbd --foreground --debug-stdout --debuglevel=1 --no-process-group


### PR DESCRIPTION
I modify several files to have the option to add UID an GID to share with other containers and no have conflicts whit user permissions in host (for example NFS volume).

I put a lot of comments in samba.sh to understand what I'm doing, and the other files can easily understand.