### PR TITLE
Added option to change from RW to RO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ ENV USER "samba"
 ENV PASS "secret"
 ENV UID 1000
 ENV GID 1000
+ENV RW true
 
 HEALTHCHECK --interval=60s --timeout=15s CMD smbclient -L \\localhost -U % -m SMB3
 

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ services:
       PASS: "secret"
       UID: 1000    # Optional, default 1000
       GID: 1000    # Optional, default 1000
+      RW: true     # Optional, default true
     ports:
       - 445:445
     volumes:

--- a/samba.sh
+++ b/samba.sh
@@ -39,6 +39,12 @@ echo -e "$PASS\n$PASS" | smbpasswd -a -s "$USER" || { echo "Failed to change Sam
 sed -i "s/^\(\s*\)force user =.*/\1force user = $USER/" "/etc/samba/smb.conf"
 sed -i "s/^\(\s*\)force group =.*/\1force group = $group/" "/etc/samba/smb.conf"
 
+# Verify if the RW variable is not equal to true (indicating read-only mode) and adjust settings accordingly
+if [[ "$RW" != "true" ]]; then
+    sed -i "s/^\(\s*\)writable =.*/\1writable = no/" "/etc/samba/smb.conf"
+    sed -i "s/^\(\s*\)read only =.*/\1read only = yes/" "/etc/samba/smb.conf"
+fi
+
 # Create shared directory and set permissions
 mkdir -p "$share" || { echo "Failed to create directory $share"; exit 1; }
 chmod -R 0770 "$share" || { echo "Failed to set permissions for directory $share"; exit 1; }


### PR DESCRIPTION
Just add a variable called RW = true, if you change, modify smb.conf to "writable = no" and "read only = yes"

Now is jut the container I wish, I use 1 internally inside VPN and other to serve in the lan the content for the TV (RO)