### PR TITLE
Container doesnt function in a config Read-Only environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ ENV PASS "secret"
 ENV UID 1000
 ENV GID 1000
 ENV RW true
+ENV CustomConfig false
+ENV CONFIG "/etc/samba/smb.conf"
 
 HEALTHCHECK --interval=60s --timeout=15s CMD smbclient -L \\localhost -U % -m SMB3
 


### PR DESCRIPTION
This use case may be different from most, but I use this container in Kubernetes and a lot of the recent changes are either misleading or do not seem well thought out.

Some background, I have been using a configMap for a while with this container in my cluster which is uneditable by the container itself.

Snippet of the deployment:
```
       spec:
            containers:
                - name: samba
                  image: ghcr.io/dockur/samba:4.19.5
                  env:
                    - name: USER
                      value:
                    - name: PASS
                      value:
                  volumeMounts:
                    - name: config
                      mountPath: /etc/samba/
                      readOnly: true
                    - name: pvc
                      mountPath: /export
                      subPath: export
            volumes:
                - name: config
                  configMap:
                    name: samba
                    items:
                        - key: smb.conf
                          path: smb.conf
```

IMO this script should not be changing anything with my config unless I ask for it, and even then it causes issues in this type of setup. I looked into this since I am now getting a `cp: can't create '/etc/samba/smb.custom': Read-only file system`

These changes should allow the use of the smb.conf file by default and not change anything unless the CustomConfig variable is enabled, at which point the script will do no further editing as it should be assumed the end user is setting up the config manually. There is no need to hand hold for a bad config, it should be fixed by the user not a catch script.

Users can specifcy a different location for the config via the CONFIG environment variable. The CustomConfig environment variable also serves as a way to stop the container from modifying even the default config if needed, although that use case is probably non-existent.