### PR TITLE
Fix: idmap range not specified for domain '*'

### DIFF
--- a/smb.conf
+++ b/smb.conf
@@ -1,4 +1,6 @@
 [global]
+        server string = samba
+        idmap config * : range = 3000-7999
         security = user
         server min protocol = SMB2
 


### PR DESCRIPTION
Fix: idmap range not specified for domain '*' from https://github.com/dockur/samba/issues/11

Error message:
idmap range not specified for domain '*'
parse_dfs_path_strict: Hostname <IP> is not ours.

idmap config settings control how Security Identifiers (SIDs) identifying Windows accounts (users, groups, and computers) are mapped to UIDs and GIDs on various Unix-like platforms. From the "Identity Mapping" chapter of the official Samba documentation: The specific setting idmap config * : range = <low> - <high> specifies how users that are not specific to a Windows domain are mapped; the "*" means "all accounts not covered by other idmap config statements." Having this in smb.conf is very important, as all the Windows "builtin" accounts and groups use this setting.

The <low> and <high> numbers simply refer to a range of otherwise unused UIDs/GIDs on the Linux server running Samba. It's important that none of these IDs be assigned to a local account or group, ever.