### PR TITLE
Fixing Issues with users.conf

### DIFF
--- a/samba.sh
+++ b/samba.sh
@@ -126,7 +126,7 @@ if [ -f "$users" ] && [ -s "$users" ]; then
         # Call the function with extracted values
         add_user "$config" "$username" "$uid" "$groupname" "$gid" "$password" || { echo "Failed to add user $username"; exit 1; }
 
-    done < "$users"
+    done < <(tr -d '\r' < "$users")
 
 else
 

--- a/samba.sh
+++ b/samba.sh
@@ -46,7 +46,8 @@ add_user() {
     fi
 
     # Check if the user is a samba user
-    if pdbedit -s "$cfg" -L | grep -q "^$username:"; then
+    pdb_output=$(pdbedit -s "$cfg" -L)  #Do not combine the two commands into one, as this could lead to issues with the execution order and proper passing of variables. 
+    if echo "$pdb_output" | grep -q "^$username:"; then
         # If the user is a samba user, update its password in case it changed
         echo -e "$password\n$password" | smbpasswd -c "$cfg" -s "$username" > /dev/null || { echo "Failed to update Samba password for $username"; return 1; }
     else


### PR DESCRIPTION
#28 
I finally found the root cause of the issue:
1.smb.conf and users.conf should be LF files, but if they are CRLF files, the previous bash script would treat the \r before the \n at the end of the line as part of the password. I have added logic to remove the \r character in the latest code, and it is now working properly. However, it is still recommended to use the LF format.
2.Some users have users.conf files that don't have a newline or a blank line at the end, causing the last line's configuration to be unrecognized. This issue was fixed in the last commit, and now all content can be correctly recognized.
3.I noticed that my log output was abnormal. Restarting Docker would output logs showing that the Samba user from the first line of users.conf was being added again. I have also fixed this issue in this update.