### PR TITLE
docs: Add quotes around $PWD

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ services:
 ##### Via Docker CLI:
 
 ```bash
-docker run -it --rm --name samba -p 445:445 -e "USER=samba" -e "PASS=secret" -v ${PWD:-.}/samba:/storage dockurr/samba
+docker run -it --rm --name samba -p 445:445 -e "USER=samba" -e "PASS=secret" -v "${PWD:-.}/samba:/storage" dockurr/samba
 ```
 
 ## Configuration ⚙️


### PR DESCRIPTION
`$PWD` might contain spaces, so expanding without quotes will result in a `docker: invalid reference format` - which is not clear for newbies