### PR TITLE
feat: optional smb password "reset", if password is not ! or * (placeholder)

### DIFF
--- a/samba.sh
+++ b/samba.sh
@@ -54,8 +54,11 @@ add_user() {
     # Check if the user is a samba user
     pdb_output=$(pdbedit -s "$cfg" -L)  #Do not combine the two commands into one, as this could lead to issues with the execution order and proper passing of variables. 
     if echo "$pdb_output" | grep -q "^$username:"; then
-        # If the user is a samba user, update its password in case it changed
-        echo -e "$password\n$password" | smbpasswd -c "$cfg" -s "$username" > /dev/null || { echo "Failed to update Samba password for $username"; return 1; }
+        # skip samba password update if password is * or !
+        if [[ "$password" != "*" && "$password" != "!" ]]; then
+            # If the user is a samba user, update its password in case it changed
+            echo -e "$password\n$password" | smbpasswd -c "$cfg" -s "$username" > /dev/null || { echo "Failed to update Samba password for $username"; return 1; }
+        fi
     else
         # If the user is not a samba user, create it and set a password
         echo -e "$password\n$password" | smbpasswd -a -c "$cfg" -s "$username" > /dev/null || { echo "Failed to add Samba user $username"; return 1; }


### PR DESCRIPTION
First of all, thank you for this project. I love the simple configuration in comparison to other samba docker projects <3
But please allow me to explain my use case, why I opened this PR:

I would like to configure users via users.conf and after getting them created, I plan to remove the plaintext passwords by using "*" or "!" as placeholder. The script will skip the password set then.

ATM I see no chance to do so, because the linux users /etc/passwd must be created after each container start / recreation. The samba users could be already created, if someone mounts /var/lib/samba to keep the database.
(I would also like to see an option to mount /var/lib/samba, but I will create another PR for this...)

I tested the changes and unless someone uses ! or * as password (:D), there should be no broken function.

Hopefully you can understand my case and agree :) Thanks in advance for your time.