### PR TITLE
feat: make /var/lib/samba and /var/cache/samba volume ready

### DIFF
--- a/samba.sh
+++ b/samba.sh
@@ -71,6 +71,7 @@ share="/storage"
 secret="/run/secrets/pass"
 config="/etc/samba/smb.conf"
 users="/etc/samba/users.conf"
+data_dir="/data"
 
 # Create shared directory
 mkdir -p "$share" || { echo "Failed to create directory $share"; exit 1; }
@@ -124,6 +125,24 @@ else
         sed -i "s/^\(\s*\)read only =.*/\1read only = yes/" "$config"
     fi
 
+fi
+
+mkdir -p $data_dir/lib $data_dir/cache
+
+# if /var/lib/samba is not a link, copy it's content to /data/lib (if empty)
+# create a softlink /var/lib/samba pointing to /data/lib
+if ! [ -L "/var/lib/samba" ]; then
+  if [ -z "$(ls -A $data_dir/lib)" ]; then
+    cp -r /var/lib/samba/* $data_dir/lib/
+  fi
+  rm -rf /var/lib/samba
+  ln -sf $data_dir/lib /var/lib/samba
+fi
+
+# create cache softlink pointing to /data/cache
+if [ ! -L "/var/cache/samba" ]; then
+  rm -rf /var/cache/samba
+  ln -sf $data_dir/cache /var/cache/samba
 fi
 
 # Check if users file is not a directory


### PR DESCRIPTION
Related to:  https://github.com/dockur/samba/pull/45

I would like to use persistent data for /var/lib/samba, to keep passwords in samba's database.
So samba users should not be created again (with password reset) and admins can get rid of plaintext passwords in users.conf (after creation).

To be honest, I got the idea from: https://github.com/crazy-max/docker-samba/blob/510903d53db39e0490d1e9ee3f1aaf6d762b96e8/rootfs/etc/cont-init.d/01-config.sh#L24

I tested it locally and I don't think this would break anything, even if users are not using a volume for /data.

Thanks in advance for your time to check :)