### PR TITLE
feat: Added Apple Time Machine parameter

### DIFF
--- a/smb.conf
+++ b/smb.conf
@@ -30,6 +30,7 @@
     # Special configuration for Apple's Time Machine
     fruit:model = TimeCapsule
     fruit:aapl = yes
+    fruit:time machine = yes
 
     # fix filenames with special chars (should be default)
     mangled names = no


### PR DESCRIPTION
- `fruit:time machine` is disabled by default
- Reference: https://www.samba.org/samba/docs/current/man-html/vfs_fruit.8.html